### PR TITLE
Fix compatibility with Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
 "scipy>=1.15, <2.0",
 "matplotlib>=3.9, <4.0",
 "absl-py>=2.1, <3.0",
-"seaborn~=0.13"
+"seaborn~=0.13",
+"orbax-checkpoint!=0.11.33; platform_system == 'Windows'",
 ]
 
 


### PR DESCRIPTION
This version of `orbax-checkpoint` (a sub-dependency of `flax`) adds `uvloop` which isn't compatible with Windows:
https://github.com/google/orbax/issues/2914

Should be fixed in a future version of `orbax-checkpoint`:
https://github.com/google/orbax/pull/2984/changes/ae44dc166a6615a7a4a704bb96882b1c0aed54f0